### PR TITLE
Avoid `KeyError: 'rev'` for special repos

### DIFF
--- a/src/piptools_sync/piptools_sync.py
+++ b/src/piptools_sync/piptools_sync.py
@@ -322,6 +322,8 @@ def yaml_to_dict(yaml_file: Path) -> dict:
         yaml_contents = yaml.safe_load(f)
     repos = {}
     for _, repo in enumerate(yaml_contents["repos"]):
+        if repo["repo"] in ("local", "meta"):
+            continue
         version = repo["rev"]
         version = _utility_remove_vee(version)
         repos[repo["repo"].strip().lower()] = version.strip()


### PR DESCRIPTION
### Description
`pre-commit` expects `rev` to be absent for special repo names:
```
An error has occurred: InvalidConfigError: 
==> File .pre-commit-config.yaml
==> At Config()
==> At key: repos
==> At Repository(repo='local')
=====> Expected rev to be absent when repo is any of ('local', 'meta'), found rev: 'v0.0.0'
```

Avoid the following exception for these special repo names
```
Traceback (most recent call last):
  File "/home/christopher.covington/.cache/pre-commit/repoo_r80vol/py_env-python3/bin/piptools_sync", line 8, in <module>
    sys.exit(main())
  File "/home/christopher.covington/.cache/pre-commit/repoo_r80vol/py_env-python3/lib/python3.9/site-packages/piptools_sync/piptools_sync.py", line 468, in main
    yaml_dict = yaml_to_dict(config_file)
  File "/home/christopher.covington/.cache/pre-commit/repoo_r80vol/py_env-python3/lib/python3.9/site-packages/piptools_sync/piptools_sync.py", line 325, in yaml_to_dict
    version = repo["rev"]
KeyError: 'rev'
```

### Checklist - did you ...
- [ ] Add a CHANGELOG entry if necessary?
- [ ] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?